### PR TITLE
Add rel-me to social links

### DIFF
--- a/layouts/partials/social-li.html
+++ b/layouts/partials/social-li.html
@@ -4,5 +4,5 @@
 {{- $svg := printf "svg/%s.svg" $id -}}
 {{- $svg = partial $svg (dict "class" "fill-current") -}}
 {{- $class = $class | default "mx-3 w-6 h-6 text-raven-700 hover:text-raven-900" -}}
-<a class="block {{ $class }}" target="_blank" rel="noopener nofollow" title="{{ T $id }}" href="{{ $url }}">{{ $svg | chomp | safeHTML }}</a>
+<a class="block {{ $class }}" target="_blank" rel="noopener nofollow me" title="{{ T $id }}" href="{{ $url }}">{{ $svg | chomp | safeHTML }}</a>
 {{- end -}}


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are owned/controlled by the same person or organisation, and is used for authentication and proving site ownership in a variety of ways.