### PR TITLE
User Config to Enable/Disable Share Services

### DIFF
--- a/data/services.toml
+++ b/data/services.toml
@@ -1,0 +1,1 @@
+share = ["facebook", "twitter"]

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -3,5 +3,7 @@
 {{- $facebookSVG := partial "svg/facebook.svg" (dict "class" "w-6 h-6 fill-current" "viewbox" "-7 -3.5 39 39") -}}
 <div class="flex items-center">
   <a class="flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "twitterShare" .) }}" href="https://twitter.com/intent/tweet?text={{ printf "%s by @%s %s" .Title $author.twitter .Permalink }}">{{ $twitterSVG }}</a>
-  <a class="ml-3 flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "facebookShare" .) }}" href="https://www.facebook.com/dialog/share?app_id={{ .Site.Params.services.facebookApp }}&display=page&href={{ .Permalink }}">{{ $facebookSVG }}</a>
+  {{ if .Site.Params.services.facebookApp }}
+    <a class="ml-3 flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "facebookShare" .) }}" href="https://www.facebook.com/dialog/share?app_id={{ .Site.Params.services.facebookApp }}&display=page&href={{ .Permalink }}">{{ $facebookSVG }}</a>
+  {{ end }}
 </div>

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,9 +1,20 @@
+{{- $currentPage := . }}
 {{- $author := partial "author-data" . -}}
 {{- $twitterSVG := partial "svg/twitter.svg" (dict "class" "w-6 h-6 fill-current") -}}
 {{- $facebookSVG := partial "svg/facebook.svg" (dict "class" "w-6 h-6 fill-current" "viewbox" "-7 -3.5 39 39") -}}
+{{- $facebookApp := .Site.Params.services.facebookApp -}}
+{{- /* Use isset instead of default to support explicit empty array */ -}}
+{{- $shares := (slice "twitter" "facebook") -}}
+{{- if isset .Site.Params.share "enable" -}}
+  {{- $shares = .Site.Params.share.enable -}}
+{{- end -}}
+{{- with $shares }}
 <div class="flex items-center">
-  <a class="flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "twitterShare" .) }}" href="https://twitter.com/intent/tweet?text={{ printf "%s by @%s %s" .Title $author.twitter .Permalink }}">{{ $twitterSVG }}</a>
-  {{ if .Site.Params.services.facebookApp }}
-    <a class="ml-3 flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "facebookShare" .) }}" href="https://www.facebook.com/dialog/share?app_id={{ .Site.Params.services.facebookApp }}&display=page&href={{ .Permalink }}">{{ $facebookSVG }}</a>
-  {{ end }}
+  {{- if in $shares "twitter" -}}
+    <a class="flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "twitterShare" $currentPage) }}" href="https://twitter.com/intent/tweet?text={{ printf "%s by @%s %s" $currentPage.Title $author.twitter $currentPage.Permalink }}">{{ $twitterSVG }}</a>
+  {{- end }}
+  {{- if in $shares "facebook" -}}
+    <a class="ml-3 flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "facebookShare" $currentPage) }}" href="https://www.facebook.com/dialog/share?app_id={{ $facebookApp }}&display=page&href={{ $currentPage.Permalink }}">{{ $facebookSVG }}</a>
+  {{- end }}
 </div>
+{{- end }}

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,20 +1,20 @@
-{{- $currentPage := . }}
+{{- $currentPage := . -}}
 {{- $author := partial "author-data" . -}}
 {{- $twitterSVG := partial "svg/twitter.svg" (dict "class" "w-6 h-6 fill-current") -}}
 {{- $facebookSVG := partial "svg/facebook.svg" (dict "class" "w-6 h-6 fill-current" "viewbox" "-7 -3.5 39 39") -}}
 {{- $facebookApp := .Site.Params.services.facebookApp -}}
+{{- $share := .Site.Data.services.share -}}
 {{- /* Use isset instead of default to support explicit empty array */ -}}
-{{- $shares := (slice "twitter" "facebook") -}}
 {{- if isset .Site.Params.share "enable" -}}
-  {{- $shares = .Site.Params.share.enable -}}
+  {{- $share = .Site.Params.share.enable -}}
 {{- end -}}
-{{- with $shares }}
+{{- with $share -}}
 <div class="flex items-center">
-  {{- if in $shares "twitter" -}}
+  {{- if in $share "twitter" }}
     <a class="flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "twitterShare" $currentPage) }}" href="https://twitter.com/intent/tweet?text={{ printf "%s by @%s %s" $currentPage.Title $author.twitter $currentPage.Permalink }}">{{ $twitterSVG }}</a>
   {{- end }}
-  {{- if in $shares "facebook" -}}
+  {{- if in $share "facebook" }}
     <a class="ml-3 flex-shrink-0 block text-raven-800 hover:text-raven-900" target="_blank" rel="noopener nofollow" title="{{ (T "facebookShare" $currentPage) }}" href="https://www.facebook.com/dialog/share?app_id={{ $facebookApp }}&display=page&href={{ $currentPage.Permalink }}">{{ $facebookSVG }}</a>
   {{- end }}
 </div>
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
Thank you for creating this awesome theme. I love it.

I propose to disable facebook share when facebookApp config is unavailable.
Facebook actually shows the following errors with empty id.

> Invalid App ID: The provided app ID does not look like a valid app ID.

![](https://user-images.githubusercontent.com/3797062/103297628-107c3200-4a3c-11eb-9375-a7e761a25a49.png)

To be honest, I'd like to disable facebook share regardless of this error, so I hope there is a configuration to control share settings in case this p-r is not accepted. What do you think?