### PR TITLE
Nicer year range in copyright note

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,8 +18,9 @@
 
     <div class="footer-copyright text-sm text-center text-gray-400 mt-4">
       {{- $copyright := (T "copyright" .) | default .Site.Copyright | default .Site.Title }}
-      &#169; {{ .Site.Params.copyrightYear }}-{{ dateFormat "2006" now.UTC }} {{ $copyright }}
-    </div>
+      {{- $currentYear := dateFormat "2006" now.UTC }}
+      &#169; {{ if lt .Site.Params.copyrightYear $currentYear }}{{ .Site.Params.copyrightYear }}-{{ end }}{{ $currentYear }} {{ $copyright }}
+    </div$>
 
     {{- if not (eq .Site.Params.disableThemeAttribution true) }}
     {{- $theme := .Scratch.Get "theme" }}


### PR DESCRIPTION
Only display a year range in the copyright footer note if `params.copyrightYear` is less than the current year (UTC). Otherwise only the current year will be shown.
