### PR TITLE
Fix config fallback for maxWidth params (marketempower#21)

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="default-single">
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <h1 class="page-title font-content-title font-normal leading-tight tracking-default text-40">{{ (T "e404Title" .) }}</h1>
 
       <article class="cdata mt-8">

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -2,7 +2,7 @@
 {{ $title := .Title | default (T .Section .) | default .Section | humanize -}}
 <div class="default-section section-{{ .Section }}">
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <h1 class="section-title font-content-sans font-semibold uppercase tracking-wide text-2xl text-raven-800">{{- $title -}}</h1>
 
       {{- with .Content }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="default-single">
   <div class="ax-title ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthTitle | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthTitle" | default "max-w-680") }}">
       <h1 class="post-title font-content-title font-normal leading-tight tracking-default text-40">{{ .Title }}</h1>
       {{- if .Params.subtitle }}
       <p class="post-subtitle font-content-sans font-light text-xl text-raven-500 mt-3">{{- partial "meta-subtitle" . | safeHTML -}}</p>
@@ -20,14 +20,14 @@
 
   {{- if .Params.feature }}
   <div class="ax-feature ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthFeature | default "max-w-5xl") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthFeature" | default "max-w-5xl") }}">
       {{- partial "feature" . }}
     </div>
   </div>
   {{- end -}}
 
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <article class="cdata">
       {{- partial "toc" . }}
       {{- .Content }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -3,7 +3,7 @@
 {{- $title := printf "%s%s %s" (T $taxonomy | default  (humanize $taxonomy)) ":" .Title -}}
 <div class="default-taxonomy">
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <h1 class="section-title font-content-sans font-semibold uppercase tracking-wide text-2xl text-raven-800">{{ $title | safeHTML }}</h1>
 
       {{- range .Paginator.Pages }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="default-terms">
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <h1 class="section-title font-content-sans font-semibold uppercase tracking-wide text-2xl text-raven-800">{{ .Title | humanize }}</h1>
 
       <div class="mt-8">

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -2,14 +2,14 @@
 <div class="page-single">
   {{ if .Params.feature -}}
   <div class="ax-feature ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthFeature | default "max-w-5xl") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthFeature" | default "max-w-5xl") }}">
       {{- partial "feature" . }}
     </div>
   </div>
   {{- end -}}
 
   <div class="ax-content ax-l-o">
-    <div class="ax-l-i{{ printf " %s" (.Params.maxWidthContent | default "max-w-680") }}">
+    <div class="ax-l-i{{ printf " %s" (.Param "maxWidthContent" | default "max-w-680") }}">
       <h1 class="page-title font-content-title font-normal leading-tight tracking-default text-40">{{ .Title }}</h1>
 
       <article class="cdata mt-8">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="ax-l-i {{ printf "%s" (.Params.maxWidthFooter | default "max-w-6xl") }}">
+  <div class="ax-l-i {{ printf "%s" (.Param "maxWidthFooter" | default "max-w-6xl") }}">
     {{- $currentPage := . }}
     <nav class="flex items-center justify-center">
       {{- range (.Site.Menus.foot) }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header id="nav" class="header">
-  <div class="ax-l-i {{ printf "%s" (.Params.maxWidthHeader | default "max-w-6xl") }}">
+  <div class="ax-l-i {{ printf "%s" (.Param "maxWidthHeader" | default "max-w-6xl") }}">
     <div class="ax-logo">
       {{- $logo := printf `<span class="font-semibold text-raven-900">%s</span>` .Site.Title }}
       {{- if (and (reflect.IsMap .Site.Params.logo) (isset .Site.Params.logo "path") (isset .Site.Params.logo "inline")) }}


### PR DESCRIPTION
Replace the use of page-level params with the `Param` method to enable proper fallback to site configuration from page frontmatter.
